### PR TITLE
Use PUSH in ninja.vdo

### DIFF
--- a/CHECKLIST_ITA.md
+++ b/CHECKLIST_ITA.md
@@ -12,6 +12,7 @@
 ## Il giorno del meetup
 
 * host edita il file speaker.html coi dati della serata
+  * Puo' essere fatto il giorno prima e lo streamer fa `git pull`
 * host attacca telecamera e microfoni
 * host avvia OBS studio
 * host si assicura che camera e microfoni vadano
@@ -21,15 +22,16 @@
 
 * speaker e host si collegano alla wifi
 
-* speaker va su https://vdo.ninja
+* speaker va su https://vdo.ninja/?push=STREAM_ID
+* va scelto uno STREAM_ID semplice! **Oppure se ne usa uno di default fornendo il link allo speaker**.
 * speaker click su screen share
 * speaker condivide lo schermo
-* speaker indica all'host l'URL https://vdo.ninja/?view=XXXXXXX
+* speaker indica all'host l'URL https://vdo.ninja/?view=STREAM_ID
   * attenzione che sia l'URL con scritto "view=" e non "push="
   * essendo lo schema dell'URL sempre quello, si può anche dettare la parte dopo view=
 
 * host va su OBS, doppio click su NinjaSlides (scena OnlySlides o SpeakerAndSlides)
-* host aggiorna l'URL di quella sorgente usando https://vdo.ninja/?view=XXXXXXX
+* host aggiorna l'URL di quella sorgente usando https://vdo.ninja/?view=STREAM_ID
 * host verifica che in SpeakerAndSlides e OnlySlides si veda lo schermo dello speaker
 
 * host deve aver configurato la streaming key usando la chiave da YouTube per questo live
@@ -40,4 +42,3 @@
   * quando gli speaker sono pronti e si parte, click su SpeakerAndSlides
   * la regia può cambiare scena secondo preferenze/necessità
   * quello che si vede nella finestra di preview è quello che si vedrà nel record/stream
-

--- a/SETUP_ITA.md
+++ b/SETUP_ITA.md
@@ -17,21 +17,23 @@ Le scene sono già pronte.
 * Collegare telecamera.
 * Collegare microfoni il pezzo a T è una "sound card" a cui va collegato il trasmettitore dei microfoni.
 * Il marchio della sound card deve essere visibile se si guarda il PC dall'alto.
-* Il cavo giusto da usare è quello con i due jack neri (dovrebbe essere già collegato alla sound card)
+* Il cavo giusto da usare è quello con i due jack neri, dovrebbe essere già collegato alla sound card.
+  * Nel caso non fosse collegato, il jack nero va nell'input rosa della sound card.
 * Il tramettitore è il pezzo in mezzo nell'astuccio dei microfoni, va collegato con un jack nero.
 * Aprire OBS Studio.
-* Import Scene, puntare alla directory che contiene scene_pymi.json
+* Import Scene, puntare alla directory che contiene scene_pymi.json oppure scene_pydata.json.
 * Ci sarà un errore perché non troverà il file speaker.html
 * OBS manderà un avviso e bisogna farlo puntare al path giusto.
 * Le scene sono WaitScreen, SpeakerAndSlides, OnlySlides, OnlySpeaker.
 * Nel caso manchi qualcosa in "Sources" per una certa scena è possibile aggiungere con tasto destro sulla scena "Add Source".
+* Per spostare elementi nella scena bisogna cliccare una volta sul lucchetto grigio dell'elemento.
 * Il setup delle slide è da fare la sera del meetup, vedi: CHECKLIST_ITA.md
 * Lo schema degli stream è in OBS-Streams.excalidraw, aprire in https://excalidraw.com/ usando "Open".
-* Bisogna cambiare il nome degli speaker in speaker.html la sera del meetup.
+* Bisogna cambiare il nome degli speaker in speaker.html la sera prima del meetup.
 
 ## Setup for PyData
 
-* a new `scene_pydata.json` has been created, it should work for both pydata and pymi setup
+* A new `scene_pydata.json` has been created, it should work for both pydata and pymi setup
 * it contains a new Background (Background PyData)
 * to switch from PyData to Pymi hide/show the correct background
 * a new Darken BG 2 has been created to fix some issues, we probably can use that also for PyMI


### PR DESCRIPTION
Use PUSH in ninja.vdo to simplify the `STREAM_ID` handover during the talk. Because we can choose a simple STREAM_ID and provide link to the speaker beforehand.